### PR TITLE
✨ Feature: 암기뷰 툴바 버튼에 피드백 기능 연결하기

### DIFF
--- a/Bettr/Bettr.xcodeproj/project.pbxproj
+++ b/Bettr/Bettr.xcodeproj/project.pbxproj
@@ -273,6 +273,8 @@
 				DEVELOPMENT_TEAM = 6CU55U45VF;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "“App needs access to the microphone.”";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "“App needs access to Speech Recognition.”\n“App needs access to Speech Recognition.”\n“App needs access to Speech Recognition.”";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -305,6 +307,8 @@
 				DEVELOPMENT_TEAM = 6CU55U45VF;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "“App needs access to the microphone.”";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "“App needs access to Speech Recognition.”\n“App needs access to Speech Recognition.”\n“App needs access to Speech Recognition.”";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Bettr/Bettr/Analyzers/SpeechAnalyzer.swift
+++ b/Bettr/Bettr/Analyzers/SpeechAnalyzer.swift
@@ -1,0 +1,119 @@
+//
+//  SpeechAnalyzer.swift
+//  Bettr
+//
+//  Created by 길정수 on 10/30/25.
+//
+
+import Foundation
+import Speech
+
+// MARK: - 분석기 (Levenshtein 기반)
+class SpeechAnalyzer {
+    
+    private let contractionDict: [String: String] = [
+        "i'm": "i am", "i've": "i have", "i'll": "i will", "i'd": "i would",
+        "you're": "you are", "you've": "you have", "you'll": "you will", "you'd": "you would",
+        "he's": "he is", "he'll": "he will", "he'd": "he would",
+        "she's": "she is", "she'll": "she will", "she'd": "she would",
+        "it's": "it is", "it'll": "it will", "it'd": "it would",
+        "we're": "we are", "we've": "we have", "we'll": "we will", "we'd": "we would",
+        "they're": "they are", "they've": "they have", "they'll": "they will", "they'd": "they would",
+        "isn't": "is not", "aren't": "are not", "wasn't": "was not", "weren't": "were not",
+        "hasn't": "has not", "haven't": "have not", "hadn't": "had not",
+        "won't": "will not", "wouldn't": "would not",
+        "don't": "do not", "doesn't": "does not", "didn't": "did not",
+        "can't": "cannot", "couldn't": "could not", "shouldn't": "should not", "mustn't": "must not"
+    ]
+    
+    // 다른 파일에서 접근 가능해야 하므로 Private 키워드 없음
+    func normalize(_ text: String) -> [String] {
+        var normalized = text.lowercased()
+        // 수축형 먼저 풀기
+        for (short, full) in contractionDict {
+            let pattern = "\\b" + NSRegularExpression.escapedPattern(for: short) + "\\b"
+            normalized = normalized.replacingOccurrences(of: pattern, with: full, options: [.regularExpression, .caseInsensitive])
+        }
+        // 문장부호 제거
+        normalized = normalized.replacingOccurrences(of: "[.,!?\"']", with: "", options: .regularExpression)
+        // 공백 정리
+        normalized = normalized.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        return normalized.split(separator: " ").map(String.init)
+    }
+    
+    func analyze(reference: String, transcription: SFTranscription) -> FeedbackResultModel {
+        let referenceWords = normalize(reference)
+        let recognizedWords = normalize(transcription.formattedString)
+        let n = referenceWords.count
+        let m = recognizedWords.count
+        
+        // Levenshtein DP 테이블
+        var dp = Array(repeating: Array(repeating: 0, count: m + 1), count: n + 1)
+        for i in 0...n { dp[i][0] = i }
+        for j in 0...m { dp[0][j] = j }
+        
+        for i in 1...n {
+            for j in 1...m {
+                if referenceWords[i - 1] == recognizedWords[j - 1] {
+                    dp[i][j] = dp[i - 1][j - 1]
+                } else {
+                    dp[i][j] = min(
+                        dp[i - 1][j] + 1,      // 삭제 (누락)
+                        dp[i][j - 1] + 1,      // 삽입 (추가)
+                        dp[i - 1][j - 1] + 1   // 치환 (대체)
+                    )
+                }
+            }
+        }
+        
+        // 추적(백트래킹)
+        var i = n
+        var j = m
+        var diffs: [WordDiff] = []
+        
+        while i > 0 || j > 0 {
+            if i > 0 && j > 0 && referenceWords[i - 1] == recognizedWords[j - 1] {
+                // 일치
+                diffs.insert(.matched(word: referenceWords[i - 1]), at: 0)
+                i -= 1
+                j -= 1
+            }
+            else if i > 0 && j > 0 && dp[i][j] == dp[i - 1][j - 1] + 1 {
+                // 대체
+                diffs.insert(.replaced(expected: referenceWords[i - 1], actual: recognizedWords[j - 1]), at: 0)
+                i -= 1
+                j -= 1
+            }
+            else if i > 0 && dp[i][j] == dp[i - 1][j] + 1 {
+                // 누락 (원본O, 발화X)
+                diffs.insert(.missing(expected: referenceWords[i - 1]), at: 0)
+                i -= 1
+            }
+            else if j > 0 && dp[i][j] == dp[i][j - 1] + 1 {
+                // 추가 (원본X, 발화O)
+                diffs.insert(.extra(actual: recognizedWords[j - 1]), at: 0)
+                j -= 1
+            } else {
+                // i=0, j=0 이거나 오류
+                break
+            }
+        }
+        
+        // 정확도 계산 (matched 기준)
+        let matchedCount = diffs.filter {
+            if case .matched = $0 { return true }
+            return false
+        }.count
+        
+        let accuracy = referenceWords.isEmpty ? 0 : Double(matchedCount) / Double(referenceWords.count)
+        
+        // FeedbackResultModel 반환
+        return FeedbackResultModel(
+            diffs: diffs,
+            accuracy: accuracy,
+            totalOriginalWords: referenceWords.count
+        )
+    }
+}

--- a/Bettr/Bettr/BettrApp.swift
+++ b/Bettr/Bettr/BettrApp.swift
@@ -23,9 +23,8 @@ struct BettrApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     var body: some Scene {
         WindowGroup {
-//            ContentView()
+            ContentView()
 //            ScriptInputView()
-            MemorizationView()
         }
     }
 }

--- a/Bettr/Bettr/ContentView.swift
+++ b/Bettr/Bettr/ContentView.swift
@@ -12,13 +12,13 @@ import FirebaseAI
 //struct ContentView: View {
 //    @State private var outputText = "아직 요청 전이에요 ✨"
 //    @State private var isLoading = false
-//    
+//
 //    var body: some View {
 //        VStack(spacing: 24) {
 //            Text("Firebase AI 테스트")
 //                .font(.title)
 //                .bold()
-//            
+//
 //            ScrollView {
 //                Text(outputText)
 //                    .padding()
@@ -27,11 +27,11 @@ import FirebaseAI
 //            .frame(height: 300)
 //            .background(Color(.secondarySystemBackground))
 //            .cornerRadius(12)
-//            
+//
 //            if isLoading {
 //                ProgressView("AI가 글을 만드는 중...")
 //            }
-//            
+//
 //            Button(action: {
 //                Task {
 //                    await callGemini()
@@ -49,27 +49,27 @@ import FirebaseAI
 //        }
 //        .padding()
 //    }
-//    
+//
 //    // MARK: - Firebase Gemini 호출
 //    func callGemini() async {
 //        isLoading = true
 //        defer { isLoading = false }
-//        
+//
 //        do {
 //            // 🔹 Gemini 모델 초기화
 //            let ai = FirebaseAI.firebaseAI(backend: .googleAI())
 //            let model = ai.generativeModel(modelName: "gemini-2.5-flash")
-//            
+//
 //            // 🔹 프롬프트
 //            let prompt = "Write a story about a magic backpack."
-//            
+//
 //            // 🔹 비동기 호출 (await)
 //            let response = try await model.generateContent(prompt)
-//            
+//
 //            // 🔹 응답 표시
 //            outputText = response.text ?? "(응답 텍스트 없음)"
 //            print("✅ Firebase Gemini 응답:", response.text ?? "없음")
-//            
+//
 //        } catch {
 //            outputText = "❌ 오류 발생: \(error.localizedDescription)"
 //            print("🔥 FirebaseAI 오류:", error.localizedDescription)
@@ -78,14 +78,28 @@ import FirebaseAI
 //}
 
 struct ContentView: View {
+    @State private var router = NavigationRouter()
+    
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        NavigationStack(path: $router.path) {
+            VStack {
+                Button("암기뷰로 이동") {
+                    router.push(.memorization(title: "스크립트.pdf"))
+                }
+            }
+            .navigationTitle("Home")
+            .navigationDestination(for: Route.self) { route in
+                switch route {
+                case .memorization(let title):
+                    MemorizationView(title: title)
+                case .recording(let sentences):
+                    RecordingView(sentences: sentences)
+                case .feedbackResult(let feedback, let sentences):
+                    FeedbackResultView(feedback: feedback, sentences: sentences)
+                }
+            }
         }
-        .padding()
+        .environment(router)
     }
 }
 

--- a/Bettr/Bettr/Models/FeedbackResultModel.swift
+++ b/Bettr/Bettr/Models/FeedbackResultModel.swift
@@ -1,0 +1,36 @@
+//
+//  FeedbackResultModel.swift
+//  Bettr
+//
+//  Created by 길정수 on 10/30/25.
+//
+
+import Foundation
+
+// MARK: - 분석 결과 상세 모델 (WordDiff)
+/// 단어별 분석 상태를 나타내는 열거형
+enum WordDiff: Hashable {
+    /// 원본과 일치하는 단어
+    case matched(word: String)
+    /// 원본에 있지만 발화에서 누락된 단어
+    case missing(expected: String)
+    /// 원본에 없지만 발화에 추가된 단어
+    case extra(actual: String)
+    /// 원본의 단어가 다른 단어로 대체된 경우
+    case replaced(expected: String, actual: String)
+}
+
+// MARK: - 분석 결과 모델
+struct FeedbackResultModel: Hashable {
+    /// 전체 스크립트에 대한 WordDiff 배열 (순서 보장)
+    let diffs: [WordDiff]
+    
+    /// 전체 정확도
+    let accuracy: Double
+    
+    /// 원본 스크립트의 총 단어 수
+    let totalOriginalWords: Int
+    
+    /// 총 녹음 시간
+    var totalRecordingTime: TimeInterval = 0.0
+}

--- a/Bettr/Bettr/Modifiers/CancelToolbar.swift
+++ b/Bettr/Bettr/Modifiers/CancelToolbar.swift
@@ -1,0 +1,31 @@
+//
+//  CancelToolbar.swift
+//  Bettr
+//
+//  Created by 길정수 on 10/30/25.
+//
+
+import SwiftUI
+
+struct CancelToolbar: ViewModifier {
+    @Environment(\.dismiss) var dismiss
+    
+    func body(content: Content) -> some View {
+        content
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(action: {
+                        dismiss()
+                    }) {
+                        Image(systemName: "xmark")
+                    }
+                }
+            }
+    }
+}
+
+extension View {
+    func cancelToolbar() -> some View {
+        self.modifier(CancelToolbar())
+    }
+}

--- a/Bettr/Bettr/Modifiers/MemorizationToolbar.swift
+++ b/Bettr/Bettr/Modifiers/MemorizationToolbar.swift
@@ -32,9 +32,12 @@ struct MemorizationToolbar: ViewModifier {
     func body(content: Content) -> some View {
         content
             .toolbar {
+                // 타이틀
                 ToolbarItem(placement: .principal) {
                     Text(title)
                 }
+                
+                // 상단 오른쪽 툴 바
                 ToolbarItem {
                     Button(action: {
                         isChunkMode.toggle()
@@ -88,6 +91,7 @@ struct MemorizationToolbar: ViewModifier {
                     }
                 }
                 
+                // 하단 툴 바
                 ToolbarItemGroup(placement: .bottomBar) {
                     // 왼쪽 버튼
                     if isPlaying {
@@ -118,7 +122,8 @@ struct MemorizationToolbar: ViewModifier {
                     Button(action: {
                         isFeedbackModalOpen.toggle()
                     }) {
-                        Image(systemName: "list.bullet.clipboard") // 이미지와 유사한 아이콘
+                        Image(systemName: "append.page")
+                            .foregroundStyle(Color.blue)
                     }
                 }
             }

--- a/Bettr/Bettr/Navigation/NavigationRouter.swift
+++ b/Bettr/Bettr/Navigation/NavigationRouter.swift
@@ -1,0 +1,32 @@
+//
+//  NavigationRouter.swift
+//  Bettr
+//
+//  Created by 길정수 on 10/30/25.
+//
+
+import SwiftUI
+import Observation
+
+@Observable
+class NavigationRouter {
+    /// 네비게이션 경로를 저장하는 변수
+    var path = NavigationPath()
+
+    /// 특정 화면을 추가 (Push 기능)
+    func push(_ route: Route) {
+        path.append(route)
+    }
+
+    /// 마지막 화면 제거 (Pop 기능)
+    func pop() {
+        if !path.isEmpty {
+            path.removeLast()
+        }
+    }
+
+    /// 네비게이션 초기화 (전체 Pop)
+    func reset() {
+        path = NavigationPath()
+    }
+}

--- a/Bettr/Bettr/Navigation/Route.swift
+++ b/Bettr/Bettr/Navigation/Route.swift
@@ -1,0 +1,14 @@
+//
+//  Route.swift
+//  Bettr
+//
+//  Created by 길정수 on 10/30/25.
+//
+
+import SwiftUI
+
+enum Route: Hashable {
+    case memorization(title: String)
+    case recording(sentences: [String])
+    case feedbackResult(result: FeedbackResultModel, sentences: [String])
+}

--- a/Bettr/Bettr/ViewModels/SpeechRecognizer.swift
+++ b/Bettr/Bettr/ViewModels/SpeechRecognizer.swift
@@ -1,0 +1,201 @@
+//
+//  SpeechRecognizer.swift
+//  Bettr
+//
+//  Created by 길정수 on 10/30/25.
+//
+
+import SwiftUI
+import Speech
+import AVFoundation
+import Combine
+
+// MARK: - 음성 인식기
+@MainActor
+class SpeechRecognizer: ObservableObject {
+    @Published var transcript = ""
+    @Published var isRecording = false
+    @Published var authorizationStatus: SFSpeechRecognizerAuthorizationStatus = .notDetermined
+    @Published var feedbackResult: FeedbackResultModel? = nil
+    
+    // 실시간 경과 시간
+    @Published var elapsedTime: TimeInterval = 0.0
+    
+    private let speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: "en"))
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private let audioEngine = AVAudioEngine()
+    
+    // 타이머 및 시작 시간 변수
+    private var timer: Timer?
+    private var recordingStartTime: Date?
+    
+    /// 전체 스크립트 문장들
+    var sentences: [String] = []
+    /// 합쳐진 전체 스크립트
+    var fullScript: String {
+        sentences.joined(separator: " ")
+    }
+    
+    init(sentences: [String]) {
+        self.sentences = sentences
+        DispatchQueue.main.async { [weak self] in
+            self?.checkAuthorization()
+        }
+    }
+    
+    // MARK: - 권한 확인
+    func checkAuthorization() {
+        SFSpeechRecognizer.requestAuthorization { [weak self] status in
+            Task { @MainActor in
+                self?.authorizationStatus = status
+            }
+        }
+    }
+    
+    // MARK: - 녹음 시작
+    func startRecording() {
+        if audioEngine.isRunning {
+            stopRecording()
+            return
+        }
+        
+        recognitionTask?.cancel()
+        recognitionTask = nil
+        
+        let audioSession = AVAudioSession.sharedInstance()
+        do {
+            try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
+            try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+        } catch {
+            print("오디오 세션 설정 실패: \(error)")
+            return
+        }
+        
+        recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
+        guard let recognitionRequest = recognitionRequest else { return }
+        recognitionRequest.shouldReportPartialResults = true
+        
+        let inputNode = audioEngine.inputNode
+        
+        recognitionTask = speechRecognizer?.recognitionTask(with: recognitionRequest) { [weak self] result, error in
+            guard let self = self else { return }
+            
+            if let result = result {
+                Task { @MainActor in
+                    self.transcript = result.bestTranscription.formattedString
+                }
+            }
+            
+            if error != nil || (result?.isFinal ?? false) {
+                // 녹음 종료 시 타이머 중지
+                self.timer?.invalidate()
+                self.timer = nil
+                
+                // 최종 녹음 시간 계산
+                let endTime = Date()
+                let totalTime = self.recordingStartTime.map { endTime.timeIntervalSince($0) } ?? 0.0
+                
+                self.audioEngine.stop()
+                inputNode.removeTap(onBus: 0)
+                self.recognitionRequest = nil
+                self.recognitionTask = nil
+                
+                Task { @MainActor in
+                    self.isRecording = false
+                    if let result = result {
+                        self.analyzeFullScript(with: result.bestTranscription, totalTime: totalTime)
+                    }
+                }
+            }
+        }
+        
+        let format = inputNode.outputFormat(forBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+            recognitionRequest.append(buffer)
+        }
+        
+        audioEngine.prepare()
+        do {
+            self.transcript = ""
+            self.feedbackResult = nil
+            try audioEngine.start()
+            
+            // 녹음 시작 시간 기록 및 타이머 시작
+            self.recordingStartTime = Date()
+            self.elapsedTime = 0.0
+            self.timer?.invalidate() // 혹시 모를 타이머 정리
+            self.timer = Timer.scheduledTimer(withTimeInterval: 0.01, repeats: true) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    guard let self = self, let startTime = self.recordingStartTime else { return }
+                    self.elapsedTime = Date().timeIntervalSince(startTime)
+                }
+            }
+            
+            isRecording = true
+            
+        } catch {
+            print("오디오 엔진 시작 실패: \(error)")
+        }
+    }
+    
+    // MARK: - 녹음 종료
+    func stopRecording() {
+        // 타이머 중지
+        timer?.invalidate()
+        timer = nil
+        
+        audioEngine.stop()
+        recognitionRequest?.endAudio()
+        audioEngine.inputNode.removeTap(onBus: 0)
+    }
+    
+    // MARK: - 녹음 취소 (분석 실행 X)
+    func cancelRecording() {
+        // 타이머 중지
+        timer?.invalidate()
+        timer = nil
+        
+        audioEngine.stop()
+        recognitionTask?.cancel()
+        recognitionTask = nil
+        recognitionRequest = nil
+        audioEngine.inputNode.removeTap(onBus: 0)
+        
+        // 상태를 수동으로 리셋
+        isRecording = false
+        transcript = ""
+        feedbackResult = nil
+    }
+    
+    // MARK: - 분석 초기화
+    func clearTranscript() {
+        transcript = ""
+        feedbackResult = nil
+    }
+    
+    // MARK: - 전체 스크립트 분석
+    func analyzeFullScript(with transcription: SFTranscription, totalTime: TimeInterval) {
+        let analyzer = SpeechAnalyzer()
+        // 10. feedback을 var로 변경
+        var feedback = analyzer.analyze(reference: fullScript, transcription: transcription)
+        
+        // 11. FeedbackSummary에 최종 시간 주입
+        feedback.totalRecordingTime = totalTime
+        
+        feedbackResult = feedback
+    }
+}
+
+// MARK: - 시간 포매터
+extension TimeInterval {
+    /// MM:SS:ms (분:초:밀리초) 형식의 문자열로 변환합니다.
+    func toMMSSms() -> String {
+        let totalSeconds = self
+        let minutes = Int(totalSeconds / 60)
+        let seconds = Int(totalSeconds.truncatingRemainder(dividingBy: 60))
+        let milliseconds = Int((totalSeconds.truncatingRemainder(dividingBy: 1)) * 100) // 3자리
+        
+        return String(format: "%02d:%02d.%02d", minutes, seconds, milliseconds)
+    }
+}

--- a/Bettr/Bettr/Views/FeedbackResultView.swift
+++ b/Bettr/Bettr/Views/FeedbackResultView.swift
@@ -1,0 +1,286 @@
+//
+//  FeedbackResultView.swift
+//  Bettr
+//
+//  Created by 길정수 on 10/30/25.
+//
+
+import Foundation
+import SwiftUI
+
+// MARK: - 피드백 결과 뷰
+struct FeedbackResultView: View {
+    let feedback: FeedbackResultModel
+    let sentences: [String]
+    
+    /// 문장별로 청크(chunk)된 Diff 배열
+    private let sentenceDiffs: [(original: String, diffs: [WordDiff])]
+    
+    /// 누락된 단어(Missing) 개수
+    private var missingCount: Int {
+        feedback.diffs.filter {
+            if case .missing = $0 { return true }
+            return false
+        }.count
+    }
+    
+    /// 추가된 단어(Extra) 개수
+    private var extraCount: Int {
+        feedback.diffs.filter {
+            if case .extra = $0 { return true }
+            return false
+        }.count
+    }
+    
+    /// 대체된 단어(Replaced) 개수
+    private var replacedCount: Int {
+        feedback.diffs.filter {
+            if case .replaced = $0 { return true }
+            return false
+        }.count
+    }
+    
+    /// 정규화 및 단어 수 계산을 위한 분석기 인스턴스
+    private let analyzer = SpeechAnalyzer()
+    
+    init(feedback: FeedbackResultModel, sentences: [String]) {
+        self.feedback = feedback
+        self.sentences = sentences
+        
+        // --- Diff 배열을 문장별로 청크로 나누는 로직 ---
+        
+        var tempDiffs = feedback.diffs
+        var chunkedResult: [(original: String, diffs: [WordDiff])] = []
+        
+        for sentence in sentences {
+            // 1. 원본 문장의 '정규화된' 단어 수 계산
+            //    (이 수만큼 .matched, .missing, .replaced 를 가져와야 함)
+            let wordCount = analyzer.normalize(sentence).count
+            
+            var chunk: [WordDiff] = []
+            var wordsTaken = 0 // 현재 청크에 할당된 '원본' 단어 수
+            
+            // 2. '원본 단어 수' 만큼 Diff를 tempDiffs에서 가져옴
+            while wordsTaken < wordCount && !tempDiffs.isEmpty {
+                let diff = tempDiffs.removeFirst()
+                chunk.append(diff)
+                
+                // .extra는 원본 단어 수에 포함되지 않으므로 세지 않음
+                switch diff {
+                case .matched, .missing, .replaced:
+                    wordsTaken += 1 // 원본 단어 수 카운트
+                case .extra:
+                    break // .extra는 카운트하지 않음
+                }
+            }
+            
+            // 3. .extra 단어는 원본 단어 사이에 끼어있을 수 있음
+            //    다음 '원본' 단어가 나오기 전까지의 .extra 단어는 현재 청크 소속임
+            while let nextDiff = tempDiffs.first,
+                  case .extra = nextDiff {
+                chunk.append(tempDiffs.removeFirst())
+            }
+            
+            chunkedResult.append((original: sentence, diffs: chunk))
+        }
+        
+        // 4. 모든 문장을 처리한 후에도 남은 Diff가 있다면 (보통 마지막 .extra)
+        //    마지막 청크에 모두 추가
+        if !tempDiffs.isEmpty {
+            if chunkedResult.isEmpty {
+                // 원본 문장이 아예 없는 경우 (방어 코드)
+                chunkedResult.append((original: "", diffs: tempDiffs))
+            } else {
+                chunkedResult[chunkedResult.count - 1].diffs.append(contentsOf: tempDiffs)
+            }
+        }
+        
+        self.sentenceDiffs = chunkedResult
+        // --- 청크 로직 끝 ---
+    }
+    
+    /// 원본 인덱스를 유지하면서 틀린 문장만 필터링합니다.
+    private var filteredSentenceDiffs: [(index: Int, data: (original: String, diffs: [WordDiff]))] {
+        sentenceDiffs.enumerated().filter { (index, data) in
+            // data.diffs (diffs 배열)에 .matched 외의 것이 하나라도 있는지 확인
+            data.diffs.contains { diff in
+                switch diff {
+                case .matched:
+                    return false // 에러가 아님 (계속 탐색)
+                case .missing, .extra, .replaced:
+                    return true // ❗️ 에러 발견! (이 문장을 포함)
+                }
+            }
+        }
+        .map { (offset, element) in
+            // (offset, element) 튜플을 (index, data) 튜플로 변환
+            return (index: offset, data: element)
+        }
+    }
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                Text("📊 피드백 결과")
+                    .font(.largeTitle).bold()
+                    .padding(.bottom, 10)
+                
+                Text("전체 정확도: \(Int(feedback.accuracy * 100))%")
+                    .font(.title)
+                    .foregroundColor(.blue)
+                    .bold()
+                
+                Text("총 녹음 시간: \(feedback.totalRecordingTime.toMMSSms())")
+                    .font(.headline)
+                    .foregroundColor(.secondary)
+                    .padding(.bottom, 5)
+                
+                HStack(spacing: 12) {
+                    Text("오류 분석:")
+                        .font(.headline)
+                        .foregroundColor(.secondary)
+                    
+                    Text("누락: \(missingCount)개")
+                        .font(.callout.bold())
+                        .foregroundColor(.green) // 누락 (Green)
+                    
+                    Text("추가: \(extraCount)개")
+                        .font(.callout.bold())
+                        .foregroundColor(.red) // 추가 (Red)
+                    
+                    Text("대체: \(replacedCount)개")
+                        .font(.callout.bold())
+                        .foregroundColor(.blue) // 대체 (Blue)
+                    
+                    Spacer()
+                }
+                .padding(.bottom, 5)
+                
+                Divider()
+                
+                // 결과 표시 로직
+                if sentenceDiffs.isEmpty {
+                    // (A) 분석 결과가 아예 없는 경우
+                    Text("분석 결과가 없습니다.")
+                        .foregroundColor(.gray)
+                } else if filteredSentenceDiffs.isEmpty {
+                    // (B) 분석은 했지만, 틀린 문장이 없는 경우 (모두 정답)
+                    VStack(alignment: .center, spacing: 10) {
+                        Text("🎉 완벽합니다!")
+                            .font(.title.bold())
+                            .foregroundColor(.green)
+                        Text("틀린 문장이 하나도 없습니다.")
+                            .font(.headline)
+                            .foregroundColor(.gray)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 20)
+                } else {
+                    // (C) 틀린 문장이 있는 경우
+                    // filteredSentenceDiffs'를 사용하고, id를 \.index로 변경
+                    ForEach(filteredSentenceDiffs, id: \.index) { (originalIndex, sentenceData) in
+                        
+                        // (1) 원본 문장
+                        VStack(alignment: .leading, spacing: 8) {
+                            // ⭐️ 4. [수정] 'index' 대신 'originalIndex' 사용
+                            Text("영어 원문 \(originalIndex + 1)")
+                                .font(.headline)
+                                .foregroundColor(.gray)
+                            Text(sentenceData.original)
+                                .font(.title3)
+                                .bold()
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color(.systemGray6))
+                        .cornerRadius(10)
+                        
+                        // (2) 사용자 발화 (하이라이트)
+                        VStack(alignment: .leading, spacing: 8) {
+                            // 'index' 대신 'originalIndex' 사용
+                            Text("내 발음 \(originalIndex + 1)")
+                                .font(.headline)
+                                .foregroundColor(.gray)
+                            
+                            // WordDiff를 Text로 변환하는 뷰
+                            buildHighlightText(from: sentenceData.diffs)
+                                .font(.title3)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .multilineTextAlignment(.leading)
+                                .lineSpacing(6)
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color(.systemGray5)) // 원본과 색 구분
+                        .cornerRadius(10)
+                        
+                        // Divider 표시 로직 변경
+                        if originalIndex != filteredSentenceDiffs.last?.index {
+                            Divider()
+                                .padding(.vertical, 10)
+                        }
+                    }
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("분석 결과")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    /// WordDiff 배열을 하이라이트된 SwiftUI Text로 변환하는 헬퍼 함수
+    ///
+    /// - 요구사항 매핑:
+    /// - 추가(extra) = 빨강 (Red)
+    /// - 누락(missing) = 초록 (Green)
+    /// - 대체(replaced) = 파랑 (Blue)
+    func buildHighlightText(from diffs: [WordDiff]) -> Text {
+        // diffs가 비어있으면 (예: 원본은 있으나 발화가 아예 없음)
+        if diffs.isEmpty {
+            return Text("(발화 내용 없음)")
+                .foregroundStyle(.gray)
+        } else {
+            // Text를 공백으로 연결
+            var components: [Text] = []
+            
+            for diff in diffs {
+                switch diff {
+                case .matched(let word):
+                    components.append(Text(word)
+                        .foregroundColor(.primary)) // 일치 (기본색)
+                    
+                case .missing(let expected):
+                    // 누락 (Green): 발화하지 않았으므로, 취소선으로 표시
+                    components.append(Text(expected)
+                        .foregroundColor(.green)
+                        .strikethrough(true, color: .green))
+                    
+                case .extra(let actual):
+                    // 추가 (Red):
+                    components.append(Text(actual)
+                        .foregroundColor(.red))
+                    
+                case .replaced(let expected, let actual):
+                    // 대체 (Blue):
+                    // (원본: 회색 취소선)
+                    components.append(Text(expected)
+                        .foregroundColor(.gray)
+                        .strikethrough(true, color: .gray))
+                    // (발음: 파란색)
+                    components.append(Text(actual)
+                        .foregroundColor(.blue))
+                }
+            }
+            
+            // components를 " " (공백)으로 합침
+            var result = Text("")
+            if let first = components.first {
+                result = first
+                for component in components.dropFirst() {
+                    result = result + Text(" ") + component
+                }
+            }
+            return result
+        }
+    }
+}

--- a/Bettr/Bettr/Views/MemorizationView.swift
+++ b/Bettr/Bettr/Views/MemorizationView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MemorizationView: View {
-    let title: String = "스크립트.pdf"
+    let title: String
     
     @State private var isChunkMode: Bool = false
     @State private var funcMode: FunctionMode = .hide
@@ -18,66 +18,66 @@ struct MemorizationView: View {
     @State private var showFeedbackModal: Bool = false
     
     var body: some View {
-        NavigationStack {
-            ZStack {
-                VStack {
-                    if isChunkMode {
-                        Text("청크모드")
-                    } else {
-                        Text("문장모드")
-                    }
-                    // 상태에 따라 다른 뷰를 표시
-                    if funcMode == .hide {
-                        Text("가리기 모드입니다.")
-                    } else {
-                        Text("재생 모드입니다.")
-                    }
-                    
-                    if langMode == .engKor {
-                        Text("한/영으로 봅니다.")
-                    } else {
-                        Text("영어만 봅니다.")
-                    }
+        ZStack {
+            VStack {
+                if isChunkMode {
+                    Text("청크모드")
+                } else {
+                    Text("문장모드")
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                // 상태에 따라 다른 뷰를 표시
+                if funcMode == .hide {
+                    Text("가리기 모드입니다.")
+                } else {
+                    Text("재생 모드입니다.")
+                }
                 
-                if showWordList {
-                    Color.black.opacity(0.001) // 시각적으로는 안 보이지만 탭 감지 가능
-                        .ignoresSafeArea()
-                        .onTapGesture {
-                            withAnimation {
-                                showWordList = false
-                            }
-                        }
-                    
-                    HStack {
-                        WordkListView()
-                    }
-                    .frame(maxWidth: .infinity, alignment: .topTrailing)
-                    .padding(.trailing, 16)
-                    .padding(.bottom, 13)
-                    .padding(.top, -40)
-                    .transition(.move(edge: .trailing).combined(with: .opacity))
+                if langMode == .engKor {
+                    Text("한/영으로 봅니다.")
+                } else {
+                    Text("영어만 봅니다.")
                 }
             }
-            .animation(.easeInOut, value: showWordList)
-            .memorizationToolbar(
-                title: title,
-                isChunkMode: $isChunkMode,
-                functionMode: $funcMode,
-                languageMode: $langMode,
-                isWordListOpen: $showWordList,
-                isPlaying: $isPlaying,
-                isFeedbackModalOpen: $showFeedbackModal
-            )
-            .toolbarBackground(Color.blue, for: .navigationBar)
-            .sheet(isPresented: $showFeedbackModal) {
-                Text("피드백 모달")
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            
+            if showWordList {
+                Color.black.opacity(0.001) // 시각적으로는 안 보이지만 탭 감지 가능
+                    .ignoresSafeArea()
+                    .onTapGesture {
+                        withAnimation {
+                            showWordList = false
+                        }
+                    }
+                
+                HStack {
+                    WordkListView()
+                }
+                .frame(maxWidth: .infinity, alignment: .topTrailing)
+                .padding(.trailing, 16)
+                .padding(.bottom, 13)
+                .padding(.top, -40)
+                .transition(.move(edge: .trailing).combined(with: .opacity))
             }
+        }
+        .animation(.easeInOut, value: showWordList)
+        .memorizationToolbar(
+            title: title,
+            isChunkMode: $isChunkMode,
+            functionMode: $funcMode,
+            languageMode: $langMode,
+            isWordListOpen: $showWordList,
+            isPlaying: $isPlaying,
+            isFeedbackModalOpen: $showFeedbackModal
+        )
+        .toolbarBackground(Color.blue, for: .navigationBar)
+        .fullScreenCover(isPresented: $showFeedbackModal) {
+            RecordingView(sentences: [
+                "I'm testing now.", "This is Test."
+            ])
         }
     }
 }
 
 #Preview {
-    MemorizationView()
+    MemorizationView(title: "스크립트.pdf")
 }

--- a/Bettr/Bettr/Views/RecordingView.swift
+++ b/Bettr/Bettr/Views/RecordingView.swift
@@ -1,0 +1,131 @@
+//
+//  RecordingView.swift
+//  Bettr
+//
+//  Created by 길정수 on 10/30/25.
+//
+
+import SwiftUI
+import Speech
+
+struct RecordingView: View {
+    @Environment(NavigationRouter.self) var router
+    @StateObject private var speechRecognizer: SpeechRecognizer
+    @State private var showEmptyTranscriptAlert = false
+    
+    init(sentences: [String]) {
+        _speechRecognizer = StateObject(wrappedValue: SpeechRecognizer(sentences: sentences))
+    }
+    
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .center, spacing: 24) {
+                Text(speechRecognizer.isRecording ? "네 듣고잇어요....": "녹음ㄱㄱ?")
+                    .font(.title2)
+                    .bold()
+                
+                // 실시간 타이머
+                if speechRecognizer.isRecording {
+                    Text(speechRecognizer.elapsedTime.toMMSSms()) // 포매터 사용
+                        .font(.headline)
+                        .foregroundColor(.gray)
+                        .padding(.bottom, 10)
+                } else {
+                    // 타이머가 없을 때 레이아웃이 깨지지 않도록 빈 공간 확보
+                    Text("00:00.00")
+                        .font(.headline)
+                        .foregroundColor(.clear) // 투명하게
+                        .padding(.bottom, 10)
+                }
+                
+                Image(systemName: "microphone")
+                    .font(.system(size: 120))
+                
+                // 버튼
+                
+                if !speechRecognizer.isRecording {
+                    VStack(spacing: 20) {
+                        Button(action: { speechRecognizer.startRecording() }) {
+                            Label("시작", systemImage:"mic.circle.fill")
+                                .padding()
+                                .frame(maxWidth: 500)
+                                .background(Color.blue)
+                                .foregroundColor(.white)
+                                .cornerRadius(12)
+                        }
+                        .disabled(speechRecognizer.authorizationStatus != .authorized)
+                        
+                        Button(action: {}) {
+                            Label("취소", systemImage: "trash")
+                                .padding()
+                                .frame(maxWidth: 500)
+                        }
+                        .hidden()
+                    }
+                    .padding(.horizontal)
+                } else {
+                    VStack(spacing: 20) {
+                        Button(action: {
+                            if speechRecognizer.transcript.isEmpty {
+                                // 텍스트가 비어있으면:
+                                // 1. 녹음을 (분석 없이) 취소합니다.
+                                speechRecognizer.cancelRecording()
+                                // 2. 알림창을 띄웁니다.
+                                showEmptyTranscriptAlert = true
+                            } else {
+                                // 텍스트가 있으면:
+                                // 정상적으로 분석을 시작합니다.
+                                speechRecognizer.stopRecording()
+                            }
+                        }) {
+                            Label("완료", systemImage: "stop.circle.fill")
+                                .padding()
+                                .frame(maxWidth: 500)
+                                .background(Color.blue)
+                                .foregroundColor(.white)
+                                .cornerRadius(12)
+                        }
+                        
+                        Button(action: {
+                            speechRecognizer.cancelRecording()
+                        }) {
+                            Label("취소", systemImage: "trash")
+                                .padding()
+                                .frame(maxWidth: 500)
+                                .background(Color.gray)
+                                .foregroundColor(.white)
+                                .cornerRadius(12)
+                        }
+                    }
+                    .padding(.horizontal)
+                }
+            }
+            .onChange(of: speechRecognizer.feedbackResult) { _, newSummary in
+                if let summary = newSummary {
+                    // 1. 결과 화면으로 이동
+                    router.push(.feedbackResult(
+                        result: summary,
+                        sentences: speechRecognizer.sentences
+                    ))
+                    
+                    // 2. 이동 직후, 다음 세션을 위해 상태를 초기화합니다.
+                    //   (transcript와 feedbackResult를 모두 초기화하는 함수 사용)
+                    speechRecognizer.clearTranscript()
+                }
+            }
+            .alert("알림", isPresented: $showEmptyTranscriptAlert) {
+                Button("확인") { }
+            } message: {
+                Text("인식된 영어 텍스트가 없습니다!")
+            }
+            .cancelToolbar()
+        }
+    }
+}
+
+#Preview {
+    RecordingView(sentences: [
+        "I'm coding now.", "This is a very long sentence.","Hello world."
+    ])
+    .environment(NavigationRouter())
+}


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #12

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

1. 피드백 기능
    - FeedbackResultModel 추가
    - SpeechAnalyzer, SpeechRecognizer 추가
    - RecordingView, FeedbackResultView 추가

2. 네비게이션 기능
    - NavigationRouter, Route 파일 추가
    - ContentView에 NavigationStack, navigationDestination 추가, 환경 변수 설정

3. 암기뷰의 툴바 버튼과 피드백 기능 연결
    - fullScreenCover로 피드백 기능이 열리게 수정
    - CancelToolbar를 만들어 fullScreenCover 모달을 닫을 수 있게 함

4. BettrApp
    - 빌드 확인을 위해 App의 페이지를 ContentView로 변경

5. 기타 사항
    - MemorizationToolbar의 아이콘 일부 수정

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x]  iPad Pro 13 (M4), iOS 26.0.1 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- MemorizationToolbar의 피드백 아이콘을 미드파이에서처럼 파란색으로 해보려고 했으나 불가능하다고 함
- 녹음, 피드백 기능을 모달로 처리하는데, 아이패드에서는 이렇게 화면 대부분을 채우는 형태이려면 sheet가 아니라 fullScreenCover를 사용해야 함, 이 fullScreenCover는 끌어내려서 닫는 기능을 제공하지 않음 (반드시 X 버튼을 클릭해서 닫아야 함)
