### PR TITLE
🐛 Bug: FeedbackResultVIew가 fullScreenCover 모달 내에서 띄워지도록 변경

### DIFF
--- a/Bettr/Bettr/ContentView.swift
+++ b/Bettr/Bettr/ContentView.swift
@@ -84,7 +84,7 @@ struct ContentView: View {
         NavigationStack(path: $router.path) {
             VStack {
                 Button("암기뷰로 이동") {
-                    router.push(.memorization(title: "스크립트.pdf"))
+                    router.push(Route.memorization(title: "스크립트.pdf"))
                 }
             }
             .navigationTitle("Home")
@@ -94,12 +94,10 @@ struct ContentView: View {
                     MemorizationView(title: title)
                 case .recording(let sentences):
                     RecordingView(sentences: sentences)
-                case .feedbackResult(let feedback, let sentences):
-                    FeedbackResultView(feedback: feedback, sentences: sentences)
                 }
             }
+            .environment(router)
         }
-        .environment(router)
     }
 }
 

--- a/Bettr/Bettr/Modifiers/CancelToolbar.swift
+++ b/Bettr/Bettr/Modifiers/CancelToolbar.swift
@@ -8,14 +8,15 @@
 import SwiftUI
 
 struct CancelToolbar: ViewModifier {
-    @Environment(\.dismiss) var dismiss
+    @Environment(\.modalDismiss) var modalDismiss
+    @Environment(\.dismiss) var defaultDismiss
     
     func body(content: Content) -> some View {
         content
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(action: {
-                        dismiss()
+                        (modalDismiss ?? defaultDismiss)()
                     }) {
                         Image(systemName: "xmark")
                     }
@@ -27,5 +28,18 @@ struct CancelToolbar: ViewModifier {
 extension View {
     func cancelToolbar() -> some View {
         self.modifier(CancelToolbar())
+    }
+}
+
+// MARK: - 커스텀 EnvironmentKey
+
+private struct ModalDismissKey: EnvironmentKey {
+    static let defaultValue: DismissAction? = nil
+}
+
+extension EnvironmentValues {
+    var modalDismiss: DismissAction? {
+        get { self[ModalDismissKey.self] }
+        set { self[ModalDismissKey.self] = newValue }
     }
 }

--- a/Bettr/Bettr/Navigation/NavigationRouter.swift
+++ b/Bettr/Bettr/Navigation/NavigationRouter.swift
@@ -12,19 +12,21 @@ import Observation
 class NavigationRouter {
     /// 네비게이션 경로를 저장하는 변수
     var path = NavigationPath()
-
+    
     /// 특정 화면을 추가 (Push 기능)
-    func push(_ route: Route) {
+    /// T라는 이름의 'Hashable' 프로토콜을 따르는
+    /// 어떤 타입이든 받을 수 있도록 제네릭 처리
+    func push<T: Hashable>(_ route: T) {
         path.append(route)
     }
-
+    
     /// 마지막 화면 제거 (Pop 기능)
     func pop() {
         if !path.isEmpty {
             path.removeLast()
         }
     }
-
+    
     /// 네비게이션 초기화 (전체 Pop)
     func reset() {
         path = NavigationPath()

--- a/Bettr/Bettr/Navigation/Route.swift
+++ b/Bettr/Bettr/Navigation/Route.swift
@@ -10,5 +10,8 @@ import SwiftUI
 enum Route: Hashable {
     case memorization(title: String)
     case recording(sentences: [String])
+}
+
+enum ModalRoute: Hashable {
     case feedbackResult(result: FeedbackResultModel, sentences: [String])
 }

--- a/Bettr/Bettr/Views/FeedbackResultView.swift
+++ b/Bettr/Bettr/Views/FeedbackResultView.swift
@@ -224,6 +224,8 @@ struct FeedbackResultView: View {
             }
             .padding()
         }
+        .navigationBarBackButtonHidden()
+        .cancelToolbar()
         .navigationTitle("분석 결과")
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/Bettr/Bettr/Views/RecordingView.swift
+++ b/Bettr/Bettr/Views/RecordingView.swift
@@ -9,7 +9,10 @@ import SwiftUI
 import Speech
 
 struct RecordingView: View {
-    @Environment(NavigationRouter.self) var router
+    @Environment(\.dismiss) var modalDismiss
+    
+    @State private var modalRouter = NavigationRouter()
+    
     @StateObject private var speechRecognizer: SpeechRecognizer
     @State private var showEmptyTranscriptAlert = false
     
@@ -18,7 +21,7 @@ struct RecordingView: View {
     }
     
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $modalRouter.path) {
             VStack(alignment: .center, spacing: 24) {
                 Text(speechRecognizer.isRecording ? "네 듣고잇어요....": "녹음ㄱㄱ?")
                     .font(.title2)
@@ -103,7 +106,7 @@ struct RecordingView: View {
             .onChange(of: speechRecognizer.feedbackResult) { _, newSummary in
                 if let summary = newSummary {
                     // 1. 결과 화면으로 이동
-                    router.push(.feedbackResult(
+                    modalRouter.push(ModalRoute.feedbackResult(
                         result: summary,
                         sentences: speechRecognizer.sentences
                     ))
@@ -119,13 +122,20 @@ struct RecordingView: View {
                 Text("인식된 영어 텍스트가 없습니다!")
             }
             .cancelToolbar()
+            .navigationDestination(for: ModalRoute.self) { route in
+                switch route {
+                case .feedbackResult(let result, let sentences):
+                    FeedbackResultView(feedback: result, sentences: sentences)
+                        .environment(\.modalDismiss, modalDismiss)
+                }
+            }
         }
     }
 }
 
 #Preview {
     RecordingView(sentences: [
-        "I'm coding now.", "This is a very long sentence.","Hello world."
+        "I'm testing now.", "This is Test."
     ])
     .environment(NavigationRouter())
 }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #15 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

1. Route파일 / ModalRoute 추가
    - fullScreenCover 내에서의 네비게이션을 다루는 ModalRoute 추가
    - 이를 사용하기 위해 NavigationRouter 내의 push 함수가 Hashable 프로토콜을 따르는 어떤 타입이든 받을 수 있도록 제네릭으로 변경

2. FeedbackResultView에 백버튼 대신 모달 닫기 버튼 적용
    - FeedbackResultView에 네비게이션으로 이동하기 때문에 기본적으로 백버튼이 나타남 (클릭시 녹음뷰로 이동)
    - 따라서 기존의 백버튼을 hidden 처리하고, CancelToolbar를 수정해 모달 닫기 기능을 사용할 수 있도록 함
    - 이 과정에서 커스텀 EnvironmentKey가 필요해 추가 -> 이 커스텀 키가 존재하는지에 따라 CancelToolbar를 클릭했을 때의 동작이 달라짐 (modalDismiss ?? defaultDismiss)
    - FeedbackResultView에 .environment(\.modalDismiss, modalDismiss)로 이 커스텀 환경 변수를 주입 -> 이 뷰에서 CancelToolbar 내 X버튼을 클릭하면 modalDismiss가 동작

3. 기타 사항
    - RecordingView의 프리뷰에 들어가는 영어원문 수정

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPad Pro 13 (M4), iOS 26.0.1 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 아직 미드파이 디자인을 반영하지 않아 다를 수 있어요.
