### PR TITLE
♻️ Refactor: 음성 인식, 마이크 권한을 녹음뷰에 들어갔을 때 한번에 받도록 변경

### DIFF
--- a/Bettr/Bettr/ViewModels/SpeechRecognizer.swift
+++ b/Bettr/Bettr/ViewModels/SpeechRecognizer.swift
@@ -16,6 +16,7 @@ class SpeechRecognizer: ObservableObject {
     @Published var transcript = ""
     @Published var isRecording = false
     @Published var authorizationStatus: SFSpeechRecognizerAuthorizationStatus = .notDetermined
+    @Published var microphoneAuthorizationStatus: AVAudioApplication.recordPermission = .undetermined
     @Published var feedbackResult: FeedbackResultModel? = nil
     
     // 실시간 경과 시간
@@ -40,15 +41,25 @@ class SpeechRecognizer: ObservableObject {
     init(sentences: [String]) {
         self.sentences = sentences
         DispatchQueue.main.async { [weak self] in
+            self?.microphoneAuthorizationStatus = AVAudioApplication.shared.recordPermission
             self?.checkAuthorization()
         }
     }
     
     // MARK: - 권한 확인
     func checkAuthorization() {
+        // 1. 음성 인식 권한 요청
         SFSpeechRecognizer.requestAuthorization { [weak self] status in
             Task { @MainActor in
                 self?.authorizationStatus = status
+            }
+        }
+        
+        // 2. 마이크 권한 명시적 요청
+        AVAudioApplication.requestRecordPermission { [weak self] granted in
+            let status: AVAudioApplication.recordPermission = granted ? .granted : .denied
+            Task { @MainActor [weak self] in
+                self?.microphoneAuthorizationStatus = status
             }
         }
     }

--- a/Bettr/Bettr/Views/RecordingView.swift
+++ b/Bettr/Bettr/Views/RecordingView.swift
@@ -56,8 +56,10 @@ struct RecordingView: View {
                                 .foregroundColor(.white)
                                 .cornerRadius(12)
                         }
-                        .disabled(speechRecognizer.authorizationStatus != .authorized)
-                        
+                        .disabled(
+                            speechRecognizer.authorizationStatus != .authorized ||
+                            speechRecognizer.microphoneAuthorizationStatus != .granted
+                        )
                         Button(action: {}) {
                             Label("취소", systemImage: "trash")
                                 .padding()


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #17

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

1. SpeechRecognizer
    - 마이크 권한 상태 변수 microphoneAuthorizationStatus 추가
    - init을 수정하여 checkAuthorization()을 호출하기 전에, 현재 마이크 권한 상태를 미리 가져오도록 함
    - checkAuthorization 함수에 마이크 권한을 명시적으로 요청하는 AVAudioApplication.requestRecordPermission 코드를 추가

2. RecordingView
    - 시작 버튼이 두 권한이 모두 허용되었을 때만 활성화되도록 .disabled() 수정자가 두 변수를 모두 확인하게 변경

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPad Pro 13 (M4), iOS 26.0.1 환경에서 정상 동작
