### PR TITLE
Bug/113

### DIFF
--- a/Bettr/Bettr/Domain/Services/WordExtractionService.swift
+++ b/Bettr/Bettr/Domain/Services/WordExtractionService.swift
@@ -27,7 +27,7 @@ class WordExtractionService {
     
     // MARK: - 🔹 Gemini 기반 단어 추출 + GRDB 저장
     func extractAndSaveWords(for scriptId: Int64) async throws {
-        // 🔸 Step 0: 이미 단어가 존재하면 바로 리턴
+        // 이미 단어가 존재하면 바로 리턴
         let existingWords = try fetchWords(for: scriptId)
         if !existingWords.isEmpty {
             print("🟢 이미 단어 \(existingWords.count)개 존재 — Gemini 호출 생략")

--- a/Bettr/Bettr/Presentation/Features/Memorization/MemorizationViewModel.swift
+++ b/Bettr/Bettr/Presentation/Features/Memorization/MemorizationViewModel.swift
@@ -214,10 +214,24 @@ final class MemorizationViewModel: TitleEditableViewModelProtocol {
     
     @MainActor
     private func loadWords() async {
+        // 이미 단어가 존재하면 Gemini 호출 생략
+        if !words.isEmpty {
+            print("🟢 이미 단어 \(words.count)개 로드됨 — Gemini 호출 생략")
+            return
+        }
+        
         isLoadingWords = true
         defer { isLoadingWords = false }
         do {
             print("🚀 [2/2] Gemini 단어 추출 시작 (MemorizationView)")
+            // Gemini 호출 전 DB에도 기존 데이터가 있는지 double-check
+            let existing = try wordExtractionService.fetchWords(for: scriptId)
+            if !existing.isEmpty {
+                print("🟢 DB에서 \(existing.count)개 단어 발견 — Gemini 호출 생략")
+                self.words = existing
+                return
+            }
+            
             try await wordExtractionService.extractAndSaveWords(for: scriptId)
             print("✅ [2/2] 단어 추출 및 저장 완료 (MemorizationView)")
             self.words = try wordExtractionService.fetchWords(for: scriptId)


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
✨ bug: WordExtractionService에 단어가 이미 존재하면 호출 생략하는 코드 추가
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #113 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- wordExtractionService에서 단어가 존재하면 호출
- Memorizationviewmodel에서 wordsload함수에서 단어가 존재했을 때 gemini 호출 생략.
---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="900" alt="image" src="https://github.com/user-attachments/assets/e3f6f70b-6d38-4670-9a94-491567f33efd" />

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] iPad Pro 13-inch, iPadOS 26 환경에서 정상 동작
- 스크립트 밖으로 나갔다가 단어장 열었을 때 재 호출 안되는 거 확인 했습니다.

---


