### PR TITLE
✨ Feature: 단어장 없을 때 처리

### DIFF
--- a/Bettr/Bettr/Presentation/Features/WordList/WordkListView.swift
+++ b/Bettr/Bettr/Presentation/Features/WordList/WordkListView.swift
@@ -14,14 +14,38 @@ struct WordkListView: View {
     @Binding var isLoading: Bool
     
     var body: some View {
-        VStack(alignment: .leading) {
+        VStack {
+            Spacer()
             
             if isLoading {
-                ProgressView("단어 불러오는 중...")
-                    .frame(maxWidth: .infinity, alignment: .center)
+                VStack(spacing: 36) {
+                    ProgressView()
+                        .controlSize(.large)
+                    
+                    VStack(spacing: 12) {
+                        Text("단어장을 불러오는 중입니다.")
+                            .font(.system(size: 20, weight: .bold))
+                        
+                        Text("잠시 기다려주세요.")
+                            .font(.system(size: 16))
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                
             } else if words.isEmpty {
-                Text("단어가 없습니다.")
-                    .foregroundStyle(.secondary)
+                VStack(spacing: 36) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.system(size: 24))
+                    
+                    VStack(spacing: 12) {
+                        Text("단어장이 비어있어요!")
+                            .font(.system(size: 20, weight: .bold))
+                        
+                        Text("추출된 단어가 없습니다.")
+                            .font(.system(size: 16))
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 ScrollView {
                     VStack {
@@ -49,7 +73,7 @@ struct WordkListView: View {
                                         .foregroundStyle(Color.indigo) // FIXME: 나중에 정식 컬러로 변경
                                     Spacer(minLength: 0)
                                 }
-
+                                
                                 if word.meaning.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                                     Text("번역 준비중…")
                                         .font(.callout)
@@ -72,6 +96,7 @@ struct WordkListView: View {
                                     }
                                 }
                             }
+                            .padding(.top, 16)
                             .padding(.bottom, 7)
                             
                             if index != words.count - 1 {
@@ -79,7 +104,9 @@ struct WordkListView: View {
                                     .frame(height: 1)
                                     .foregroundStyle(.white) // FIXME: 나중에 정식 컬러로 변경
                             }
+
                         }
+                        .padding(.leading, 36)
                     }
                 }
                 .scrollIndicators(.hidden)
@@ -87,8 +114,7 @@ struct WordkListView: View {
             
             Spacer()
         }
-        .padding(.top, 36)
-        .padding(.leading, 36)
+        .padding(.top, 12)
         .frame(maxWidth: 360, maxHeight: .infinity, alignment: .topLeading)
         .clipShape(RoundedRectangle(cornerRadius: 35))
         .background(


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #127 

---

### 🧶 주요 변경 내용 (Summary)

- 단어장 로딩중 화면 추가
- 단어장에 단어가 비었을 때, 보여지는 뷰 추가
- 단어 뜻에서 숫자 제거
- 단어 구분선 삐져나가는 이슈 수정
- 프리뷰에서 확인하기 위한 코드 추가

---

### 📸 스크린샷 (Optional)
- 비었을 때
<img width="2752" height="2064" alt="Simulator Screenshot - iPad Pro 13-inch (M5) - 2025-11-10 at 21 33 16" src="https://github.com/user-attachments/assets/03f7ef65-1ff1-4b1b-a571-3f6926556d62" />
- 로딩중일 때
<img width="2752" height="2064" alt="Simulator Screenshot - iPad Pro 13-inch (M5) - 2025-11-10 at 21 35 35" src="https://github.com/user-attachments/assets/b31b080a-aae1-4d9d-8715-593b2220e46c" />

---

### 🧪 테스트 / 검증 내역

- [x] UI 정상 동작 확인

---

### 💬 기타 공유 사항

- 색상은 등록안된 것도 있고, 이름이 바뀐다고 해서 추후에 수정하겠습니다!