### PR TITLE
🐛 Bug: 녹음 후 오디오 재생이 안되는 문제 해결

### DIFF
--- a/Bettr/Bettr.xcodeproj/project.pbxproj
+++ b/Bettr/Bettr.xcodeproj/project.pbxproj
@@ -346,7 +346,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = RAXCR9X83K;
+				DEVELOPMENT_TEAM = 6CU55U45VF;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "텍스트 스크립트 생성을 위해 카메라 접근이 필요합니다.";
@@ -384,7 +384,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = RAXCR9X83K;
+				DEVELOPMENT_TEAM = 6CU55U45VF;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "텍스트 스크립트 생성을 위해 카메라 접근이 필요합니다.";

--- a/Bettr/Bettr/Presentation/Services/AudioPlaybackService.swift
+++ b/Bettr/Bettr/Presentation/Services/AudioPlaybackService.swift
@@ -25,12 +25,26 @@ final class AudioPlaybackService: NSObject, AVSpeechSynthesizerDelegate {
     override init() {
         super.init()
         synthesizer.delegate = self
-        
+    }
+    
+    // --- Private Session Helpers ---
+    
+    /// 재생 세션을 활성화하고 카테고리를 .playback으로 설정합니다.
+    private func activatePlaybackSession() {
         do {
             try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
             try AVAudioSession.sharedInstance().setActive(true)
         } catch {
-            print("Failed to set up audio session: \(error.localizedDescription)")
+            print("Failed to activate playback session: \(error.localizedDescription)")
+        }
+    }
+    
+    /// 오디오 세션을 비활성화합니다. (다른 앱이 오디오를 사용할 수 있도록)
+    private func deactivateSession() {
+        do {
+            try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        } catch {
+            print("Failed to deactivate audio session: \(error.localizedDescription)")
         }
     }
     
@@ -40,6 +54,8 @@ final class AudioPlaybackService: NSObject, AVSpeechSynthesizerDelegate {
     func play(text: String, language: String = "en-US") {
         
         stop() // 기존 큐 중지
+        
+        activatePlaybackSession()
         
         // 읽어주기를 원하는 텍스트를 큐에 넣고 읽기 요청
         let utterance = createUtterance(text: text, language: language)
@@ -52,6 +68,8 @@ final class AudioPlaybackService: NSObject, AVSpeechSynthesizerDelegate {
     /// 스크립트 전체 문장을 순서대로 재생합니다. (전체 재생 버튼용)
     func playAll(sentences: [SentenceData], language: String = "en-US") {
         stop() // 기존 큐 중지
+        
+        activatePlaybackSession()
         
         // SentenceData 배열을 AVSpeechUtterance 배열로 변환
         self.utteranceQueue = sentences
@@ -66,12 +84,14 @@ final class AudioPlaybackService: NSObject, AVSpeechSynthesizerDelegate {
     func pause() {
         if synthesizer.isSpeaking {
             synthesizer.pauseSpeaking(at: .immediate)
+            deactivateSession()
         }
     }
     
     /// 일시 중지된 지점부터 다시 재생합니다.
     func resume() {
         if synthesizer.isPaused {
+            activatePlaybackSession()
             synthesizer.continueSpeaking()
         }
     }
@@ -82,6 +102,7 @@ final class AudioPlaybackService: NSObject, AVSpeechSynthesizerDelegate {
             synthesizer.stopSpeaking(at: .immediate)
             utteranceQueue.removeAll()
             isPlaying = false
+            deactivateSession()
         }
     }
     
@@ -93,6 +114,7 @@ final class AudioPlaybackService: NSObject, AVSpeechSynthesizerDelegate {
             playNextInQueue()
         } else {
             isPlaying = false
+            deactivateSession()
         }
     }
     
@@ -125,6 +147,7 @@ final class AudioPlaybackService: NSObject, AVSpeechSynthesizerDelegate {
         guard !utteranceQueue.isEmpty else {
             // 큐가 비었으면 재생 완료
             isPlaying = false
+            deactivateSession()
             return
         }
         

--- a/Bettr/Bettr/Presentation/Services/SpeechRecognizer.swift
+++ b/Bettr/Bettr/Presentation/Services/SpeechRecognizer.swift
@@ -115,6 +115,10 @@ class SpeechRecognizer: ObservableObject {
                 self.recognitionRequest = nil
                 self.recognitionTask = nil
                 
+                // 오디오 세션 비활성화
+                let audioSession = AVAudioSession.sharedInstance()
+                try? audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+                
                 let totalTime = self.recordingStartTime.map { Date().timeIntervalSince($0) } ?? 0.0
                 let finalTranscript = result?.bestTranscription.formattedString ?? ""
                 
@@ -170,6 +174,10 @@ class SpeechRecognizer: ObservableObject {
         audioEngine.stop()
         recognitionRequest?.endAudio()
         audioEngine.inputNode.removeTap(onBus: 0)
+        
+        // 오디오 세션 비활성화
+        let audioSession = AVAudioSession.sharedInstance()
+        try? audioSession.setActive(false, options: .notifyOthersOnDeactivation)
     }
     
     // MARK: - 녹음 취소 (분석 실행 X)
@@ -184,7 +192,11 @@ class SpeechRecognizer: ObservableObject {
         recognitionRequest = nil
         audioEngine.inputNode.removeTap(onBus: 0)
         
-        // 상태를 수동으로 리셋
+        // 오디오 세션 비활성화
+        let audioSession = AVAudioSession.sharedInstance()
+        try? audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+        
+        // 상태 리셋
         isRecording = false
         transcript = ""
         self.hasRecorded = false
@@ -202,8 +214,8 @@ class SpeechRecognizer: ObservableObject {
         elapsedTime = 0.0
         
         lastTranscription = nil
-                lastRecordedDuration = 0.0
-                recordingDidFinishEmpty = false
+        lastRecordedDuration = 0.0
+        recordingDidFinishEmpty = false
     }
     
     // MARK: - 녹음 분석


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #204

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

RecordingView의 SpeechRecognizer가 사용한 .record 오디오 세션과 MemorizationView의 AudioPlaybackService가 사용하는 .playback 세션 간의 충돌로 인해 문제가 발생

1. SpeechRecognizer
    - 녹음이 중지/취소/완료되는 모든 시점(stopRecording, cancelRecording, recognitionTask 클로저)에 오디오 세션을 확실히 비활성화(setActive(false))하도록 수정

2. AudioPlaybackService
    - init 시점이 아닌, 실제 재생이 필요한 시점(play, playAll, resume)에 세션을 .playback 모드로 활성화(setActive(true))하도록 변경
    - 재생이 종료되거나 멈추는 시점(stop, pause, didFinish)에 세션을 비활성화(setActive(false))하여, 다른 오디오 기능(녹음 등)과 충돌하지 않도록 수정
 
---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] 유닛 테스트 정상 동작
- [x] iPad Pro M4 13-inch, iPadOS 26 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 이 문제로 재생이 안되는 문제는 해결 완 했습니다
- 다른 원인으로 재생이 잘 안되는걸 발견한다면 다시 알려주세요
