### PR TITLE
♻️ Refactor: 대시보드 뷰의 자주 틀린 단어 영역 타이틀 수정 ("Top3"라는 문구 제거)

### DIFF
--- a/Bettr/Bettr/Presentation/Features/ScriptDashboard/Components/ScriptDashboardTopRightContents.swift
+++ b/Bettr/Bettr/Presentation/Features/ScriptDashboard/Components/ScriptDashboardTopRightContents.swift
@@ -16,7 +16,7 @@ struct ScriptDashboardTopRightContents: View {
             
             // 자주 틀린 단어
             VStack(alignment: .leading, spacing: 0) {
-                Text("자주 틀린 단어 Top 3")
+                Text("자주 틀린 단어")
                     .font(.calloutRegular16)
                     .foregroundStyle(.normalBlack900)
                 


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #233

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 대시보드 뷰의 자주 틀린 단어 영역 타이틀 수정 ("Top3"라는 문구 제거)

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="2752" height="2064" alt="image" src="https://github.com/user-attachments/assets/bbe643c1-8ad2-4c93-9130-1cf60acd2905" />

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] 유닛 테스트 정상 동작
- [x] iPad Pro M4 13-inch, iPadOS 26 환경에서 정상 동작
