### PR TITLE
bug: 제목 편집 중일 때 분석 및 암기 버튼을 누르면 편집중인 제목이 저장할 때 반영이 안되는 이슈 해결

### DIFF
--- a/Bettr/Bettr/Presentation/Features/ScriptConfirm/ScriptConfirmView.swift
+++ b/Bettr/Bettr/Presentation/Features/ScriptConfirm/ScriptConfirmView.swift
@@ -104,6 +104,7 @@ struct ScriptConfirmView: View {
             // 분석 및 저장 버튼
             Button(action: {
                 Task {
+                    isTitleEditing = false
                     // 🔹 추가됨: 타임아웃 플래그 초기화
                     didTimeout = false
                     


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: bug: 제목 편집 중일 때 분석 및 암기 버튼을 누르면 편집중인 제목이 저장할 때 반영이 안되는 이슈 해결
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #252 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 버튼에 istitleediting = false 추가

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] 유닛 테스트 정상 동작
- [x] iPad Air 5 11-inch, iPadOS 26 환경에서 정상 동작

