### PR TITLE
🎨 Design: 홈뷰에서 스크롤을 올릴 경우 패딩 조절

### DIFF
--- a/Bettr/Bettr/Presentation/Features/Home/Components/Scripts/ScriptGridView.swift
+++ b/Bettr/Bettr/Presentation/Features/Home/Components/Scripts/ScriptGridView.swift
@@ -34,6 +34,7 @@ struct ScriptGridView: View {
                         .padding(EdgeInsets(top: 16, leading: 16, bottom: 24, trailing: 16))
                     }
                 }
+                .padding(.top, 76)
             } else {
                 // Fallback on earlier versions
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: 220))], spacing: 60) {
@@ -51,6 +52,7 @@ struct ScriptGridView: View {
                         .padding(EdgeInsets(top: 16, leading: 16, bottom: 24, trailing: 16))
                     }
                 }
+                .padding(.top, 76)
             }
         }
         .scrollIndicators(.hidden)

--- a/Bettr/Bettr/Presentation/Features/Home/HomeView.swift
+++ b/Bettr/Bettr/Presentation/Features/Home/HomeView.swift
@@ -18,7 +18,7 @@ struct HomeView: View {
     private let pdfTextExtractor = PDFTextExtractor()
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 84) {
+        VStack(alignment: .leading, spacing: 8) {
             MainHeaderView()
                 .padding(.top, 48)
                 .padding(.horizontal, 84)


### PR DESCRIPTION
…패딩 변경

<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #256

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- `HomeView`에 있는 VStack spacing 일부를 `ScriptGridView`로 이동하여 스크롤을 위로 올릴 시 패딩을 8로 변경합니다.

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] 유닛 테스트 정상 동작
- [x] iPad Pro M4 13-inch, iPadOS 26 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 큰 수정은 아니니 얼른 리뷰해주세요!
